### PR TITLE
Use argparse in assembler

### DIFF
--- a/binutils/asm/asm.py
+++ b/binutils/asm/asm.py
@@ -1,47 +1,38 @@
-#An assembler for RISC-V v2.2 Base integer instruction set 
-
 from tokenizer import *
 from parser import *
 from encoder import *
-import sys
 import os
+import argparse
+
+parser = argparse.ArgumentParser(description='A RISC-V RV32I assembler')
+parser.add_argument('-i', dest='inFile', type=str, help='Path to source file')
+parser.add_argument('-o', dest='outFile', type=str, help='Path to binary output file')
 
 class Assembler:
   def __init__(self):
     self.token_stream = []
 
-  def assemble(self, asm_source_path):
+  def assemble(self, asm_source_path, bin_path):
     asm_source = open(asm_source_path, mode='r', encoding="utf-8")
     asm_lines = asm_source.read().splitlines() 
     num_line = 0
 
     for asm_line in asm_lines:
-      print(asm_line)
       tokenizer = Tokenizer(asm_line, num_line)
       self.token_stream.extend(tokenizer.tokenize())
       num_line = num_line + 1
 
     parser = Parser(self.token_stream)
     ast = parser.parse()
-    print(parser.symbol_table)
 
     encoder = Encoder(ast)
-    encoder.encode(asm_source_path)
+    encoder.encode(asm_source_path, bin_path)
 
 if __name__ == "__main__":
-  numArgs = len(sys.argv)
-  args = sys.argv
+  args = parser.parse_args()
 
-  if numArgs == 3:
-    if args[1] != "-i":
-      print("Unrecognized parameter '" + args[1] + "'. Usage: asm.py -i path/to/source.asm")
-    else:
-      inputSourcePath = args[2]
-
-      if not os.path.exists(inputSourcePath):
-        print("File does not exist at path '" + inputSourcePath + "'")
-      else:
-        assembler = Assembler()
-        assembler.assemble(inputSourcePath)
+  if not os.path.exists(args.inFile):
+    print(f"File does not exist at path {args.inFile}")
   else:
-    print("Unexpected number of parameters. Usage: asm.py -i path/to/source.asm")
+    assembler = Assembler()
+    assembler.assemble(args.inFile, args.outFile)

--- a/binutils/asm/encoder.py
+++ b/binutils/asm/encoder.py
@@ -72,9 +72,14 @@ class Encoder:
             "{:02x}".format((num >> 16) & 255) + " " +
             "{:02x}".format((num >> 24) & 255)
     )
-  def encode(self, asm_source_path):
-    bin_path = asm_source_path.split(".")[0] + ".o"
-    mem_path = asm_source_path.split(".")[0] + ".mem"
+
+  def encode(self, asm_source_path, bin_path):
+    if not bin_path:
+      bin_path = asm_source_path.rsplit(".", 1)[0] + ".o"
+      mem_path = asm_source_path.rsplit(".", 1)[0] + ".mem"
+    else:
+      mem_path = bin_path.rsplit(".", 1)[0] + ".mem"
+
     out_bin = open(bin_path, "wb")
     out_mem = open(mem_path, "w")
 
@@ -136,7 +141,6 @@ class Encoder:
     op = entry["op"]
     funct3 = entry["funct3"]
 
-    print(stmt.imm)
     imm4_1 = (stmt.imm >> 1) & 0b1111
     imm10_5 = (stmt.imm >> 5) & 0b111111
     imm11 = (stmt.imm >> 11) & 0b1

--- a/chip/imem.v
+++ b/chip/imem.v
@@ -9,7 +9,7 @@ module imem(
     integer i;
 
     initial begin
-        $readmemh("rv32i.mem", mem);
+        $readmemh("code.mem", mem);
     end
 
     always @(state) begin

--- a/test/invoke_cpu.sh
+++ b/test/invoke_cpu.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-python3 ../binutils/asm/asm.py -i rv32i.asm
+python3 ../binutils/asm/asm.py -i rv32i.asm -o code.o
 cd ../chip
 iverilog -o ../test/test.chip ../test/test.v
 cd ../test


### PR DESCRIPTION
- Simplify assembler CLI by using argparse
- Allow custom output file name
- Modify `imem` to load `code.mem`. This way every test asm can be compiled to `code.mem` and the `imem` will pick it up and load it.