### PR TITLE
Expand li pseudoinstruction

### DIFF
--- a/binutils/asm/tokenizer.py
+++ b/binutils/asm/tokenizer.py
@@ -67,8 +67,10 @@ class Tokenizer:
       "jal": True,
       "jalr": True,
       "lui": True,
-      "auipc": True
+      "auipc": True,
+      "li": True
     }
+    
     self.abi_id_to_index = {
       "zero": 0, 	#hardwired to 0, ignores writes	n/a
       "ra": 1, #return address for jumps	no

--- a/sample/li_test.asm
+++ b/sample/li_test.asm
@@ -1,0 +1,3 @@
+li x1, 0xABCDEFFF
+li x2, 1
+add x3, x1, x2


### PR DESCRIPTION
Implement load immediate (`li`) pseudo instruction.
This pseudo op loads a 32bit immediate into the destination register.
It is expanded to a sequence of `lui` and `addi`. `lui` adds the upper 20 bits to the destination register, filling in the lower 12 bits with zeros, and `addi` then adds the lower 12 bits. The tricky part here is that `addi` is an I-type instruction, which means that the 12 bit immediate is sign-extended, so the calculation for the upper 20 bits is:

_from_
`hi20 + sext(lo12) = 32bit_imm`
_we get_
`hi20 = 32bit_imm - sext(lo12)`

TODO:

- general solution for pseudo op expansion (t's ugly now)
- refactor opportunity: sign extension is used in emulation and assembler as well, we should refactor them to a common util