### PR TITLE
Fix sequential logic and make assignments non-blocking

### DIFF
--- a/chip/rtl/alu.v
+++ b/chip/rtl/alu.v
@@ -1,4 +1,5 @@
 module alu(
+    input clk,
     input [2:0] state,
     input [31:0] rs1_val,
     input [31:0] rs2_val,
@@ -39,7 +40,7 @@ module alu(
     reg[63:0] srai;
     reg[63:0] sra;
 
-    always @(*) begin
+    always @(posedge clk) begin
         if (state == 3'd5) begin
             sext_rs1 = { {32{rs1_val[31]}}, rs1_val };
             srai = sext_rs1 >> imm[4:0];

--- a/chip/rtl/branch.v
+++ b/chip/rtl/branch.v
@@ -1,4 +1,5 @@
 module branch(
+    input clk,
     input [2:0] state,
     input [31:0] rs1_val,
     input [31:0] rs2_val,
@@ -15,24 +16,24 @@ module branch(
 
     reg _taken_branch = 0;
 
-    always @(*) begin
+    always @(posedge clk) begin
         if (state == 3'd4) begin
             if (is_beq) begin
-                _taken_branch = rs1_val == rs2_val;
+                _taken_branch <= rs1_val == rs2_val;
             end else if (is_bne) begin
-                _taken_branch = rs1_val != rs2_val;
+                _taken_branch <= rs1_val != rs2_val;
             end else if (is_bge) begin
-                _taken_branch = (rs1_val >= rs2_val) ^ (rs1_val[31] != rs2_val[31]);
+                _taken_branch <= (rs1_val >= rs2_val) ^ (rs1_val[31] != rs2_val[31]);
             end else if (is_bgeu) begin
-                _taken_branch = rs1_val >= rs2_val;
+                _taken_branch <= rs1_val >= rs2_val;
             end else if (is_blt) begin
-                _taken_branch = (rs1_val < rs2_val) ^ (rs1_val[31] != rs2_val[31]);
+                _taken_branch <= (rs1_val < rs2_val) ^ (rs1_val[31] != rs2_val[31]);
             end else if (is_bltu) begin
-                _taken_branch = rs1_val < rs2_val;
+                _taken_branch <= rs1_val < rs2_val;
             end else if (is_jal || is_jalr) begin
-                _taken_branch = 1;
+                _taken_branch <= 1;
             end else begin
-                _taken_branch = 0;
+                _taken_branch <= 0;
             end
         end
     end

--- a/chip/rtl/cpu.v
+++ b/chip/rtl/cpu.v
@@ -10,7 +10,7 @@ module cpu(
         input uart_txd_in,
         output uart_rxd_out
     );
-    reg[31:0] pc = -4;
+    reg[31:0] pc = 0;
     reg read_en;
     wire [31:0] instr;
 
@@ -97,6 +97,7 @@ module cpu(
 
     // Decode
     decode dec(
+        CLK100MHZ,
         state,
         instr,
         rs1,
@@ -154,6 +155,7 @@ module cpu(
     );
 
     rf register_file(
+        CLK100MHZ,
         state,
         rs1_en, 
         rs1, 
@@ -169,6 +171,7 @@ module cpu(
     );
 
     alu calc(
+        CLK100MHZ,
         state,
         rs1_val,
         rs2_val,
@@ -228,6 +231,7 @@ module cpu(
     );
 
     branch b(
+        CLK100MHZ,
         state,
         rs1_val,
         rs2_val,
@@ -244,10 +248,10 @@ module cpu(
 
     always @ (posedge CLK100MHZ) begin
         if (state == 3'd7) begin
-            pc = taken_branch ? address : (pc + 4);
+            pc <= taken_branch ? address : (pc + 4);
         end
 
-        state = (state % 7) + 1;
+        state <= (state % 7) + 1;
     end
 
 endmodule

--- a/chip/rtl/decode.v
+++ b/chip/rtl/decode.v
@@ -1,4 +1,5 @@
 module decode(
+    input clk,
     input [2:0] state,
     input [31:0] instr, 
     output [4:0] rs1,
@@ -117,7 +118,7 @@ module decode(
 
     reg [10:0] decode_bits;
     
-    always @(*) begin
+    always @(posedge clk) begin
         if (state == 3'd2) begin
             _is_i_type = (instr[6:2] == 5'b00000) || (instr[6:2] == 5'b00100) || (instr[6:2] == 5'b11001);
             _is_r_type = instr[6:2] == 5'b01100;

--- a/chip/rtl/gpio.v
+++ b/chip/rtl/gpio.v
@@ -36,7 +36,7 @@ module gpio(
         byte_read //out
     );
 
-    always @(*) begin
+    always @(posedge clk) begin
         port_select = address % 8;
 
         if (state == 3'd6 && enabled) begin

--- a/chip/rtl/mem.v
+++ b/chip/rtl/mem.v
@@ -1,4 +1,5 @@
 module mem(
+    input clk,
     input [2:0] state,
     input enabled,
     input load_enable,
@@ -25,33 +26,33 @@ module mem(
         $readmemh("code.mem", mem);
     end
 
-    always @(*) begin
+    always @(posedge clk) begin
         if (state == 3'd1) begin
-            _instr_out = { mem[pc + 3], mem[pc + 2], mem[pc + 1], mem[pc] };
+            _instr_out <= { mem[pc + 3], mem[pc + 2], mem[pc + 1], mem[pc] };
         end else if (state == 3'd6 && enabled) begin
             if (load_enable) begin
                 if (is_lb) begin
-                    data = { {24{mem[address][7]}}, mem[address] };
+                    data <= { {24{mem[address][7]}}, mem[address] };
                 end else if (is_lh) begin
-                    data = { {16{mem[address][15]}}, mem[address + 1], mem[address] };
+                    data <= { {16{mem[address][15]}}, mem[address + 1], mem[address] };
                 end else if (is_lbu) begin
-                    data = { 24'b0, mem[address] };
+                    data <= { 24'b0, mem[address] };
                 end else if (is_lhu) begin
-                    data = { 16'b0, mem[address + 1], mem[address] };
+                    data <= { 16'b0, mem[address + 1], mem[address] };
                 end else begin
-                    data = { mem[address + 3], mem[address + 2], mem[address + 1], mem[address] };
+                    data <= { mem[address + 3], mem[address + 2], mem[address + 1], mem[address] };
                 end
             end else if (store_enable) begin
                 if (is_sb) begin
-                    mem[address] = data_in[7:0];
+                    mem[address] <= data_in[7:0];
                 end else if (is_sh) begin
-                    mem[address] = data_in[7:0];
-                    mem[address + 1] = data_in[15:8];
+                    mem[address] <= data_in[7:0];
+                    mem[address + 1] <= data_in[15:8];
                 end else begin
-                    mem[address] = data_in[7:0];
-                    mem[address + 1] = data_in[15:8];
-                    mem[address + 2] = data_in[23:16];
-                    mem[address + 3] = data_in[31:24];
+                    mem[address] <= data_in[7:0];
+                    mem[address + 1] <= data_in[15:8];
+                    mem[address + 2] <= data_in[23:16];
+                    mem[address + 3] <= data_in[31:24];
                 end
             end
         end

--- a/chip/rtl/mmu.v
+++ b/chip/rtl/mmu.v
@@ -29,6 +29,7 @@ module mmu(
     wire [31:0] _gpio_out;
 
     mem bram(
+        clk,
         state,
         en_bram,
         load_enable,

--- a/chip/rtl/rf.v
+++ b/chip/rtl/rf.v
@@ -1,4 +1,5 @@
 module rf(
+    input clk,
     input [2:0] state,
     input rs1_en, 
     input [4:0] rs1,
@@ -25,10 +26,10 @@ module rf(
             registers[i] = 0;
     end
 
-    always @(*) begin
+    always @(posedge clk) begin
         if (state == 3'd3) begin
-            _rs1_val = rs1_en ? registers[rs1] : 0;
-            _rs2_val = rs2_en ? registers[rs2] : 0;
+            _rs1_val <= rs1_en ? registers[rs1] : 0;
+            _rs2_val <= rs2_en ? registers[rs2] : 0;
         end else if (state == 3'd7 && rd_en && rd != 0) begin
             registers[rd] = is_load ? load_result : alu_result;
 

--- a/chip/rtl/uart.v
+++ b/chip/rtl/uart.v
@@ -28,38 +28,38 @@ end
 
 always @(sample_tick) begin
     if (uart_txd_in == 0 && state == 2'b00) begin
-        counter = counter + 1;
-
-        if (counter == 8) begin
-            _byte_read = 0;
-            _byte = 0;
-            state = 2'b01;
-            counter = 0;
+        if (counter == 7) begin
+            _byte_read <= 0;
+            _byte <= 0;
+            state <= 2'b01;
+            counter <= 0;
+        end else begin
+            counter <= counter + 1;
         end
     end else if (state == 2'b01) begin
-        counter = counter + 1;
-
         if (bit_counter == 8) begin
-            bit_counter = 0;
-            state = 2'b11;
+            bit_counter <= 0;
+            state <= 2'b10;
+        end else if (counter == 15) begin
+            _byte <= _byte | (uart_txd_in << bit_counter);
+            counter <= 0;
+            bit_counter <= bit_counter + 1;
+        end else begin
+            counter <= counter + 1;
         end
-
-        if (counter == 16) begin
-            _byte = _byte | (uart_txd_in << bit_counter);
-            counter = 0;
-            bit_counter = bit_counter + 1;
-        end
-    end else if (state == 2'b11) begin
-        counter = counter + 1;
-
-        if (counter == 16 && uart_txd_in == 1) begin
-            _byte_read = 1;
-            counter = 0;
-            state = 2'b00; //idle
+    end else if (state == 2'b10) begin
+        if (counter == 15) begin
+            if (uart_txd_in == 1) begin
+                _byte_read <= 1;
+                counter <= 0;
+                state <= 2'b00; //idle
+            end
+        end else begin
+            counter <= counter + 1;
         end
     end else begin
-        _byte_read = 0;
-        _byte = 0;
+        _byte_read <= 0;
+        _byte <= 0;
     end
 end
 

--- a/chip/tb/uart_cpu_test.v
+++ b/chip/tb/uart_cpu_test.v
@@ -9,7 +9,7 @@ module test_uart_with_cpu;
     reg rx = 1;
     wire [3:0] leds;
 
-    reg [7:0] exe[0:112];
+    reg [7:0] exe[0:51];
     reg start_transmission = 0;
 
     initial begin
@@ -27,7 +27,7 @@ module test_uart_with_cpu;
 
     //Transmission side
     always @(posedge tx_clk) begin
-        if (start_transmission == 1 && byte_counter < 112) begin
+        if (start_transmission == 1 && byte_counter < 52) begin
             i = i + 1;
             
             if (i == 0) begin //start bit

--- a/chip/tb/uart_test.v
+++ b/chip/tb/uart_test.v
@@ -22,7 +22,7 @@ module test_uart;
     end
 
     initial begin
-        # 4166670 
+        # 4218753 
         if (msg[0] == msg_back[0] && 
             msg[1] == msg_back[1] && 
             msg[2] == msg_back[2] && 

--- a/os/bootloader.asm
+++ b/os/bootloader.asm
@@ -1,22 +1,22 @@
 ;load an exe from UART
-li x1, 0x1004    ; uart_byte port
-li x2, 0x1005    ; uart_ready port
-li x3, 0x200     ; address of executable (first 4 bytes will be exe size)
-mv x6, x3        
-li x9, 0         ; iterator, or address of 
-li x10, 4        ; size of exe is stored in 4 bytes
-li x11, 0        ; size of executable stored here
-lbu x4, 0(x2)    ; while (!(*(uart_ready))) ;
+li x1, 0x1004
+li x2, 0x1005
+li x3, 0x200
+mv x6, x3
+li x9, 0
+li x10, 4
+li x11, 0
+lbu x4, 0(x2)
 beq x4, x0, -4
-bne x9, x10, 12  ; if (i == 4) {
-lw x11, 0(x3)    ;  size_of_exe = *((uint32_t*) exe));
-addi x11, x11, 4 ;  size_of_exe += 4; }
-lbu x5, 0(x1)    ; cur_byte = *uart_byte;
-add x6, x3, x9   ; exe += i;
-sb x5, 0(x6)     ; *exe = cur_byte
-addi x9, x9, 1   ; i += 1
-beq x11, x9, 16  ; if (i == size_of_exe) goto load program
-lbu x4, 0(x2)    ; while (*uart_ready) ;
+bne x9, x10, 12
+lw x11, 0(x3)
+addi x11, x11, 4
+lbu x5, 0(x1)
+add x6, x3, x9
+sb x5, 0(x6)
+addi x9, x9, 1
+beq x11, x9, 16
+lbu x4, 0(x2)
 bne x4, x0, -4
-jal x0, -48      ; goto start of routine
-jalr x0, 4(x3)   ; execute loaded program, 4 byte offset is needed because
+jal x0, -48
+jalr x0, 4(x3)

--- a/sample/led_blink.asm
+++ b/sample/led_blink.asm
@@ -1,5 +1,5 @@
 li x1, 0
-li x2, 0x10000 ;base led pointer
+li x2, 0x1000 ;base led pointer
 li x3, 0x6ACFC0
 addi x3, x3, -1
 bne x3, x0, -4

--- a/test/test.v
+++ b/test/test.v
@@ -9,7 +9,7 @@ module test;
     wire [3:0] leds;
 
     initial begin
-        # 100000 $finish;
+       # 100000 $finish;
     end
 
     always #5 clk = !clk;


### PR DESCRIPTION
- CPU modules were implemented as combinational always blocks, but they in fact need to be sequential. To make them sequential, the always blocks has been changed to be triggered by the positive edge of the clock. 
- A lot of assignments were defined as blocking, but they were not dependent on eachother, so most of them has been refactored to be non-blocking.