### PR TITLE
Fix synthesis issues and board constraints

### DIFF
--- a/chip/fpga/arty_a7/arty_a7_35t.xdc
+++ b/chip/fpga/arty_a7/arty_a7_35t.xdc
@@ -3,6 +3,10 @@
 ## - uncomment the lines corresponding to used pins
 ## - rename the used ports (in each line, after get_ports) according to the top level signal names in the project
 
+## FPGA Configuration I/O Options
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]
+
 ## Clock signal
 set_property -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports { CLK100MHZ }]; #IO_L12P_T1_MRCC_35 Sch=gclk[100]
 create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { CLK100MHZ }];

--- a/chip/rtl/decode.v
+++ b/chip/rtl/decode.v
@@ -133,7 +133,7 @@ module decode(
 
             _rs1_valid = !_is_u_type && !_is_j_type;
             _rs2_valid = _is_s_type || _is_r_type || _is_b_type;
-            _rd_valid = !is_s_type && !is_b_type;
+            _rd_valid = !_is_s_type && !_is_b_type;
 
 
             // Decode immediate based on instruction type

--- a/chip/rtl/gpio.v
+++ b/chip/rtl/gpio.v
@@ -22,7 +22,7 @@ module gpio(
     output uart_rxd_out
 );
 
-    reg [3:0] led;
+    reg [3:0] led = 4'b1111;
     reg [31:0] data;
     reg [2:0] port_select;
     wire [7:0] byte;

--- a/chip/rtl/uart.v
+++ b/chip/rtl/uart.v
@@ -12,54 +12,49 @@ reg [10:0] uart_tick = 0;
 reg [7:0] _byte = 0;
 reg _byte_read = 0;
 reg [3:0] bit_counter = 0;
-reg sample_tick = 0;
 
 //9600 baud rate
 //sample 16 times 9600 -> 153600 -> 100MHz clock -> 651 clock tick produces 1 uart sample tick
 always @(posedge clk) begin
-    if (uart_tick == 325) begin
-        sample_tick <= ~sample_tick;
+    if (uart_tick == 651) begin
         uart_tick <= 0;
-    end else begin 
-        uart_tick <= uart_tick + 1;
-    end
-end
 
-
-always @(posedge sample_tick) begin
-    if (uart_txd_in == 0 && state == 2'b00) begin
-        if (counter == 7) begin
-            _byte_read <= 0;
-            _byte <= 0;
-            state <= 2'b01;
-            counter <= 0;
-        end else begin
-            counter <= counter + 1;
-        end
-    end else if (state == 2'b01) begin
-        if (bit_counter == 8) begin
-            bit_counter <= 0;
-            state <= 2'b10;
-        end else if (counter == 15) begin
-            _byte <= _byte | (uart_txd_in << bit_counter);
-            counter <= 0;
-            bit_counter <= bit_counter + 1;
-        end else begin
-            counter <= counter + 1;
-        end
-    end else if (state == 2'b10) begin
-        if (counter == 15) begin
-            if (uart_txd_in == 1) begin
-                _byte_read <= 1;
+        if (uart_txd_in == 0 && state == 2'b00) begin
+            if (counter == 7) begin
+                _byte_read <= 0;
+                _byte <= 0;
+                state <= 2'b01;
                 counter <= 0;
-                state <= 2'b00; //idle
+            end else begin
+                counter <= counter + 1;
+            end
+        end else if (state == 2'b01) begin
+            if (bit_counter == 8) begin
+                bit_counter <= 0;
+                state <= 2'b10;
+            end else if (counter == 15) begin
+                _byte <= _byte | (uart_txd_in << bit_counter);
+                counter <= 0;
+                bit_counter <= bit_counter + 1;
+            end else begin
+                counter <= counter + 1;
+            end
+        end else if (state == 2'b10) begin
+            if (counter == 15) begin
+                if (uart_txd_in == 1) begin
+                    _byte_read <= 1;
+                    counter <= 0;
+                    state <= 2'b00; //idle
+                end
+            end else begin
+                counter <= counter + 1;
             end
         end else begin
-            counter <= counter + 1;
+            _byte_read <= 0;
+            _byte <= 0;
         end
     end else begin
-        _byte_read <= 0;
-        _byte <= 0;
+        uart_tick <= uart_tick + 1;
     end
 end
 


### PR DESCRIPTION
- Fix `rd_valid` decoding: It was wrong, as it used output registers to determine if `rd` is valid for the given instruction. For some reason it only manifested in Vivado simulation and on board, but not in icarus verilog. 
- Fix board voltage constraints.
- Refactor `uart` module `always` block to be triggered by clock instead of sample_tick signal.