### PR TITLE
Update sample asm to use new mmio ports, simplify uart transmission

### DIFF
--- a/chip/rtl/uart_tx.v
+++ b/chip/rtl/uart_tx.v
@@ -24,7 +24,7 @@ always @(posedge clk) begin
                 _tx_ready <= 0;
                 _uart_rxd_out <= 0;
             end else if (tx_counter < 9 && tx_counter > 0) begin
-                _uart_rxd_out <= (byte >> (tx_counter - 1)) & 1;
+                _uart_rxd_out <= byte[tx_counter - 1];
             end else begin //stop bit
                 _uart_rxd_out <= 1;
                 tx_counter <= 0;

--- a/chip/tb/uart_test.v
+++ b/chip/tb/uart_test.v
@@ -13,7 +13,7 @@ module test_uart;
     reg [7:0] msg[0:3];
     reg [7:0] msg_back[0:3];
     integer i = -1;
-    integer byte_counter = 0;
+    reg [1:0] byte_counter = 0;
     reg [7:0] cur_byte;
 
     initial begin

--- a/os/bootrom.asm
+++ b/os/bootrom.asm
@@ -1,6 +1,6 @@
 ;load an exe from UART
-li x1, 0x1004
-li x2, 0x1005
+li x1, 0x32007 ;rx_byte
+li x2, 0x32008 ;rx_byte_ready
 li x3, 0x200
 mv x6, x3
 li x9, 0

--- a/sample/led_blink.asm
+++ b/sample/led_blink.asm
@@ -1,6 +1,6 @@
 li x1, 0
-li x2, 0x1000 ;base led pointer
-li x3, 0x6ACFC0
+li x2, 0x32000 ;base led pointer
+li x3, 0xBEBC20
 addi x3, x3, -1
 bne x3, x0, -4
 xori x1, x1, 1

--- a/sample/switches.asm
+++ b/sample/switches.asm
@@ -1,5 +1,5 @@
-li x1, 0x1000 ;led base
-li x2, 0x1006 ;switch base
+li x1, 0x32000 ;led base
+li x2, 0x32009 ;switch base
 lbu x3, 0(x2) ;sw[0]
 lbu x4, 1(x2) ;sw[1]
 lbu x5, 2(x2) ;sw[2]


### PR DESCRIPTION
- Simplify bit access of `tx_byte` in `uart_tx`
- Update `mmio` ports in test asm files

`uart_tx` has been tested on board. _"Hello World!"_ has been successfully sent from the board to the host using `PySerial`.