### PR TITLE
Increase mem size to 128K

### DIFF
--- a/chip/rtl/mem.v
+++ b/chip/rtl/mem.v
@@ -6,7 +6,7 @@ module mem
     //--------------------------------------------------------------------------
     parameter   NUM_COL             =   4,
     parameter   COL_WIDTH           =   8,
-    parameter   ADDR_WIDTH          =  10,
+    parameter   ADDR_WIDTH          =  15,
     // Addr  Width in bits : 2 *ADDR_WIDTH = RAM Depth
     parameter   DATA_WIDTH      =  NUM_COL*COL_WIDTH  // Data  Width in bits
     //----------------------------------------------------------------------

--- a/chip/rtl/mmio.v
+++ b/chip/rtl/mmio.v
@@ -23,7 +23,7 @@ module mmio(
     output uart_rxd_out,
     input [3:0] sw
 );
-    wire en_bram = (address >= 0) && (address < 'h2404);
+    wire en_bram = (address >= 0) && (address < 'h8000);
     wire en_gpio = (address >= 'h32000);
     wire [31:0] _bram_out;
     wire [31:0] _gpio_out;
@@ -72,14 +72,14 @@ module mmio(
         .clkA(clk),
         .enaA(1'd1),
         .weA(4'd0),
-        .addrA(pc[11:2]),
+        .addrA(pc[16:2]),
         .dinA(32'd0),
         .doutA(instr_out),
         //Port B is for memory
         .clkB(clk),
         .enaB(en_bram),
         .weB(weB_calc),
-        .addrB(address[11:2]),
+        .addrB(address[16:2]),
         .dinB(data_in_calc),
         .doutB(_bram_out)
     );

--- a/sample/mul_test.asm
+++ b/sample/mul_test.asm
@@ -1,0 +1,17 @@
+li x1, 0x32000 ;led base
+li x2, 101
+li x3, 100
+mul x4, x2, x3
+andi x5, x4, 1
+sb x5, 0(x1)
+srli x5, x4, 1
+andi x5, x5, 1
+sb x5, 1(x1)
+srli x5, x4, 2
+andi x5, x5, 1
+sb x5, 2(x1)
+srli x5, x4, 3
+andi x5, x5, 1
+sb x5, 3(x1)
+jal x0, 0
+


### PR DESCRIPTION
- Mem size is bumped up to 128K (0x8000, or 32K words)
- Added `mul_test.asm` sample code to test muldiv operations. `mul` works, but `div`, and related operations don't seem to perform nominally, we need proper divide module and not rely on `/` operation.