### PR TITLE
Refactor divider trigger to prevent ininite loop

### DIFF
--- a/chip/rtl/alu.v
+++ b/chip/rtl/alu.v
@@ -59,6 +59,7 @@ module alu(
     reg [31:0] divisor;
     reg [31:0] dividend;
 
+    reg div_triggered = 0;
     reg div_start = 0;       // start signal
     wire div_busy;           // calculation in progress
     wire div_valid;          // quotient and remainder are valid
@@ -83,8 +84,8 @@ module alu(
 
     always @(posedge clk) begin
         if (state == `WRITE_BACK) begin
-            wait_mul <= 0;
-            div_start <= 0;
+            wait_mul = 0;
+            div_triggered = 0;
         end else if (state == `EXECUTE) begin
 
             // Since mul and div instructions don't finish in 
@@ -192,11 +193,12 @@ module alu(
                     dividend = rs1_val;
                     divisor = rs2_val;
                 end
-
-                if (!div_start) begin
+            
+                if (!div_triggered) begin
                     div_start = 1;
+                    div_triggered = 1;
                     _should_stall = 1;
-                end else if (div_busy) begin
+                end else if (div_start) begin
                     div_start = 0;
                 end else if (div_valid) begin
                     if (is_div) begin

--- a/chip/rtl/cpu.v
+++ b/chip/rtl/cpu.v
@@ -302,7 +302,7 @@ module cpu(
             state <= (state + 1) % 5;
         end
 
-        if (state == 3'd4) begin
+        if (state == `WRITE_BACK) begin
             pc <= taken_branch ? address : (pc + 4);
         end
     end

--- a/chip/rtl/divider.v
+++ b/chip/rtl/divider.v
@@ -3,9 +3,9 @@
 module divider(
     input clk,
     input start,          // start signal
-    output reg busy,      // calculation in progress
-    output reg valid,     // quotient and remainder are valid
-    output reg dbz,       // divide by zero flag
+    output busy,      // calculation in progress
+    output valid,     // quotient and remainder are valid
+    output dbz,       // divide by zero flag
     input  [31:0] x,      // dividend
     input  [31:0] y,      // divisor
     output reg [31:0] q,  // quotient
@@ -16,6 +16,10 @@ reg [31:0] y1;              // copy of divisor
 reg [31:0] q1, q1_next;     // intermediate quotient
 reg [32:0] ac, ac_next;     // accumulator (1 bit wider)
 reg [4:0] i;                // iteration counter
+
+reg _busy = 0;
+reg _valid = 0;
+reg _dbz = 0;
 
 always@* begin
     if (ac >= {1'b0,y1}) begin
@@ -28,21 +32,21 @@ end
 
 always@(posedge clk) begin
     if (start) begin
-        valid <= 0;
+        _valid <= 0;
         i <= 0;
         if (y == 0) begin  // catch divide by zero
-            busy <= 0;
-            dbz <= 1;
+            _busy <= 0;
+            _dbz <= 1;
         end else begin  // initialize values
-            busy <= 1;
-            dbz <= 0;
+            _busy <= 1;
+            _dbz <= 0;
             y1 <= y;
             {ac, q1} <= {{32{1'b0}}, x, 1'b0};
         end
-    end else if (busy) begin
+    end else if (_busy) begin
         if (i == 31) begin  // we're done
-            busy <= 0;
-            valid <= 1;
+            _busy <= 0;
+            _valid <= 1;
             q <= q1_next;
             r <= ac_next[32:1];  // undo final shift
         end else begin  // next iteration
@@ -52,5 +56,9 @@ always@(posedge clk) begin
         end
     end
 end
+
+assign dbz = _dbz;
+assign valid = _valid;
+assign busy = _busy;
 
 endmodule

--- a/sample/mul_test.asm
+++ b/sample/mul_test.asm
@@ -1,6 +1,6 @@
 li x1, 0x32000 ;led base
-li x2, 101
-li x3, 100
+li x2, 10
+li x3, 2
 mul x4, x2, x3
 andi x5, x4, 1
 sb x5, 0(x1)

--- a/test/run_chip_test.py
+++ b/test/run_chip_test.py
@@ -18,6 +18,12 @@ def get_expected_regs(regs_path):
 
         return out
 
+tests = [
+    "loadstore.asm",
+    "rv32i.asm",
+    "rv32m.asm",
+    "csr.asm"
+]
 def run_test(test_case):
     compile_command = f'python3 ../binutils/asm/asm.py -i {test_case["asm"]} -o code.o'
     run_command =  "cd ../chip/rtl;"
@@ -41,7 +47,7 @@ def run_test(test_case):
 
     print(f'{test_case["asm"]} PASSED')
 
-for test_asm in glob.glob("*.asm"):
+for test_asm in tests:
     run_test({ 
         "asm": test_asm, 
         "regs": get_expected_regs(os.path.splitext(test_asm)[0] + ".regs")


### PR DESCRIPTION
- Divider was stuck in an infinite loop on the FPGA because the start signal was kept being sent
- Introduce a new signal that stays high until the whole divide operation completes, which in combination with the `div_start` signal can be used to properly control the start of the division
- Refactor chip unit tests: instead of finding test `.asm`-s with `glob`, explicitly define test cases, so it's easy to disable/enable tests as we like